### PR TITLE
[Forked] Avoid using extra_dejson method on connection in KiotaRequestAdapterHook to avoid AsyncToSync RuntimeError

### DIFF
--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/hooks/msgraph.py
@@ -17,6 +17,7 @@
 # under the License.
 from __future__ import annotations
 
+import asyncio
 import json
 import warnings
 from ast import literal_eval
@@ -28,7 +29,6 @@ from typing import TYPE_CHECKING, Any, cast
 from urllib.parse import quote, urljoin, urlparse
 
 import httpx
-from asgiref.sync import sync_to_async
 from azure.identity import CertificateCredential, ClientSecretCredential
 from httpx import AsyncHTTPTransport, Response, Timeout
 from kiota_abstractions.api_error import APIError
@@ -61,7 +61,7 @@ if TYPE_CHECKING:
     from kiota_abstractions.response_handler import NativeResponseType
     from kiota_abstractions.serialization import ParsableFactory
 
-    from airflow.models import Connection
+    from airflow.providers.microsoft.azure.version_compat import Connection
 
 
 class DefaultResponseHandler(ResponseHandler):
@@ -250,7 +250,9 @@ class KiotaRequestAdapterHook(BaseHook):
     def _build_request_adapter(self, connection) -> tuple[str, RequestAdapter]:
         client_id = connection.login
         client_secret = connection.password
-        config = connection.extra_dejson if connection.extra else {}
+        # TODO: do not use connection.extra_dejson until it's fixed in Airflow otherwise expect:
+        #       RuntimeError: You cannot use AsyncToSync in the same thread as an async event loop.
+        config = json.loads(connection.extra) if connection.extra else {}
         api_version = self.get_api_version(config)
         host = self.get_host(connection)  # type: ignore[arg-type]
         base_url = self.get_base_url(host, api_version, config)
@@ -342,6 +344,15 @@ class KiotaRequestAdapterHook(BaseHook):
         self.api_version = api_version
         return request_adapter
 
+    @classmethod
+    async def get_async_connection(cls, conn_id: str) -> Connection:
+        if hasattr(BaseHook, "aget_connection"):
+            return await BaseHook.aget_connection(conn_id=conn_id)
+
+        from asgiref.sync import sync_to_async
+
+        return await sync_to_async(BaseHook.get_connection)(conn_id=conn_id)
+
     async def get_async_conn(self) -> RequestAdapter:
         """Initiate a new RequestAdapter connection asynchronously."""
         if not self.conn_id:
@@ -350,7 +361,7 @@ class KiotaRequestAdapterHook(BaseHook):
         api_version, request_adapter = self.cached_request_adapters.get(self.conn_id, (None, None))
 
         if not request_adapter:
-            connection = await sync_to_async(self.get_connection)(conn_id=self.conn_id)
+            connection = await self.get_async_connection(conn_id=self.conn_id)
             api_version, request_adapter = self._build_request_adapter(connection)
         self.api_version = api_version
         return request_adapter
@@ -417,7 +428,7 @@ class KiotaRequestAdapterHook(BaseHook):
     def test_connection(self):
         """Test HTTP Connection."""
         try:
-            self.run()
+            asyncio.run(self.run())
             return True, "Connection successfully tested"
         except Exception as e:
             return False, str(e)

--- a/providers/microsoft/azure/src/airflow/providers/microsoft/azure/version_compat.py
+++ b/providers/microsoft/azure/src/airflow/providers/microsoft/azure/version_compat.py
@@ -40,9 +40,10 @@ if AIRFLOW_V_3_0_PLUS:
         BaseOperator,
         BaseOperatorLink,
         BaseSensorOperator,
+        Connection,
     )
 else:
-    from airflow.models import BaseOperator, BaseOperatorLink
+    from airflow.models import BaseOperator, BaseOperatorLink, Connection  # type: ignore[assignment]
     from airflow.sensors.base import BaseSensorOperator  # type: ignore[no-redef]
 
 if AIRFLOW_V_3_1_PLUS:
@@ -61,5 +62,6 @@ __all__ = [
     "BaseOperator",
     "BaseOperatorLink",
     "BaseSensorOperator",
+    "Connection",
     "XCOM_RETURN_KEY",
 ]

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/hooks/test_msgraph.py
@@ -21,7 +21,7 @@ import inspect
 from json import JSONDecodeError
 from os.path import dirname
 from typing import TYPE_CHECKING, cast
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from httpx import Response
@@ -47,6 +47,7 @@ from airflow.providers.microsoft.azure.hooks.msgraph import (
 
 from tests_common.test_utils.file_loading import load_file_from_resources, load_json_from_resources
 from tests_common.test_utils.providers import get_provider_min_airflow_version
+from unit.microsoft.azure.base import Base
 from unit.microsoft.azure.test_utils import (
     get_airflow_connection,
     mock_connection,
@@ -62,18 +63,8 @@ if TYPE_CHECKING:
         AzureIdentityAccessTokenProvider,
     )
 
-try:
-    import importlib.util
 
-    if not importlib.util.find_spec("airflow.sdk.bases.hook"):
-        raise ImportError
-
-    BASEHOOK_PATCH_PATH = "airflow.sdk.bases.hook.BaseHook"
-except ImportError:
-    BASEHOOK_PATCH_PATH = "airflow.hooks.base.BaseHook"
-
-
-class TestKiotaRequestAdapterHook:
+class TestKiotaRequestAdapterHook(Base):
     @staticmethod
     def assert_tenant_id(request_adapter: RequestAdapter, expected_tenant_id: str):
         adapter: HttpxRequestAdapter = cast("HttpxRequestAdapter", request_adapter)
@@ -90,13 +81,13 @@ class TestKiotaRequestAdapterHook:
         assert tenant_id == expected_tenant_id
 
     def test_get_conn(self):
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=get_airflow_connection,
-        ):
+        with self.patch_hook():
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
 
-            with pytest.warns(DeprecationWarning, match="get_conn is deprecated"):
+            with pytest.warns(
+                DeprecationWarning,
+                match="get_conn is deprecated, please use the async get_async_conn method!"
+            ):
                 actual = hook.get_conn()
 
             assert isinstance(actual, HttpxRequestAdapter)
@@ -104,10 +95,7 @@ class TestKiotaRequestAdapterHook:
 
     @pytest.mark.asyncio
     async def test_get_async_conn(self):
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=get_airflow_connection,
-        ):
+        with self.patch_hook():
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
             actual = await hook.get_async_conn()
 
@@ -122,10 +110,7 @@ class TestKiotaRequestAdapterHook:
             api_version="v1",
         )
 
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=connection,
-        ):
+        with self.patch_hook(side_effect=connection):
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
             actual = await hook.get_async_conn()
 
@@ -141,10 +126,7 @@ class TestKiotaRequestAdapterHook:
             proxies="{'http': 'http://proxy:80', 'https': 'https://proxy:80'}",
         )
 
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=connection,
-        ):
+        with self.patch_hook(side_effect=connection):
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
             actual = await hook.get_async_conn()
 
@@ -161,10 +143,7 @@ class TestKiotaRequestAdapterHook:
             proxies='["http://proxy:80", "https://proxy:80"]',
         )
 
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=connection,
-        ):
+        with self.patch_hook(side_effect=connection):
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
 
             with pytest.raises(AirflowConfigException):
@@ -179,10 +158,7 @@ class TestKiotaRequestAdapterHook:
             proxies='{"http": "http://proxy:80", "https": "https://proxy:80"}',
         )
 
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=connection,
-        ):
+        with self.patch_hook(side_effect=connection):
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
             actual = await hook.get_async_conn()
 
@@ -191,19 +167,13 @@ class TestKiotaRequestAdapterHook:
             assert actual._http_client._mounts.get(URLPattern("https://"))
 
     def test_scopes_when_default(self):
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=get_airflow_connection,
-        ):
+        with self.patch_hook():
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
 
             assert hook.scopes == [KiotaRequestAdapterHook.DEFAULT_SCOPE]
 
     def test_scopes_when_passed_as_string(self):
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=get_airflow_connection,
-        ):
+        with self.patch_hook():
             hook = KiotaRequestAdapterHook(
                 conn_id="msgraph_api", scopes="https://microsoft.sharepoint.com/.default"
             )
@@ -211,10 +181,7 @@ class TestKiotaRequestAdapterHook:
             assert hook.scopes == ["https://microsoft.sharepoint.com/.default"]
 
     def test_scopes_when_passed_as_list(self):
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=get_airflow_connection,
-        ):
+        with self.patch_hook():
             hook = KiotaRequestAdapterHook(
                 conn_id="msgraph_api", scopes=["https://microsoft.sharepoint.com/.default"]
             )
@@ -222,58 +189,40 @@ class TestKiotaRequestAdapterHook:
             assert hook.scopes == ["https://microsoft.sharepoint.com/.default"]
 
     def test_api_version(self):
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=get_airflow_connection,
-        ):
+        with self.patch_hook():
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api", api_version=APIVersion.v1.value)
 
             assert hook.api_version == APIVersion.v1.value
 
     def test_api_version_when_none_is_explicitly_passed_as_api_version(self):
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=get_airflow_connection,
-        ):
+        with self.patch_hook():
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api", api_version=None)
 
             assert not hook.api_version
 
     def test_get_api_version_when_empty_config_dict(self):
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=get_airflow_connection,
-        ):
+        with self.patch_hook():
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
             actual = hook.get_api_version({})
 
             assert actual == APIVersion.v1.value
 
     def test_get_api_version_when_api_version_in_config_dict(self):
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=get_airflow_connection,
-        ):
+        with self.patch_hook():
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
             actual = hook.get_api_version({"api_version": "beta"})
 
             assert actual == APIVersion.beta.value
 
     def test_get_api_version_when_custom_api_version_in_config_dict(self):
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=get_airflow_connection,
-        ):
+        with self.patch_hook():
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api", api_version="v1")
             actual = hook.get_api_version({})
 
             assert actual == "v1"
 
     def test_get_host_when_connection_has_scheme_and_host(self):
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=get_airflow_connection,
-        ):
+        with self.patch_hook():
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
             connection = mock_connection(schema="https", host="graph.microsoft.de")
             actual = hook.get_host(connection)
@@ -281,10 +230,7 @@ class TestKiotaRequestAdapterHook:
             assert actual == NationalClouds.Germany.value
 
     def test_get_host_when_connection_has_no_scheme_or_host(self):
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=get_airflow_connection,
-        ):
+        with self.patch_hook():
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
             connection = mock_connection()
             actual = hook.get_host(connection)
@@ -293,10 +239,7 @@ class TestKiotaRequestAdapterHook:
 
     @pytest.mark.asyncio
     async def test_tenant_id(self):
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=get_airflow_connection,
-        ):
+        with self.patch_hook():
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
             actual = await hook.get_async_conn()
 
@@ -304,15 +247,12 @@ class TestKiotaRequestAdapterHook:
 
     @pytest.mark.asyncio
     async def test_azure_tenant_id(self):
-        airflow_connection = lambda conn_id: get_airflow_connection(
+        connection = lambda conn_id: get_airflow_connection(
             conn_id=conn_id,
             azure_tenant_id="azure-tenant-id",
         )
 
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=airflow_connection,
-        ):
+        with self.patch_hook(side_effect=connection):
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
             actual = await hook.get_async_conn()
 
@@ -333,10 +273,7 @@ class TestKiotaRequestAdapterHook:
             api_version="v1",
         )
 
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=connection,
-        ):
+        with self.patch_hook(side_effect=connection):
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
             request_info = hook.request_information(url="myorg/admin/apps", query_parameters={"$top": 5000})
             request_adapter = await hook.get_async_conn()
@@ -348,10 +285,7 @@ class TestKiotaRequestAdapterHook:
 
     @pytest.mark.asyncio
     async def test_throw_failed_responses_with_text_plain_content_type(self):
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=get_airflow_connection,
-        ):
+        with self.patch_hook():
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
             response = Mock(spec=Response)
             response.headers = {"content-type": "text/plain"}
@@ -368,10 +302,7 @@ class TestKiotaRequestAdapterHook:
 
     @pytest.mark.asyncio
     async def test_throw_failed_responses_with_application_json_content_type(self):
-        with patch(
-            f"{BASEHOOK_PATCH_PATH}.get_connection",
-            side_effect=get_airflow_connection,
-        ):
+        with self.patch_hook():
             hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
             response = Mock(spec=Response)
             response.headers = {"content-type": "application/json"}

--- a/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_msgraph.py
+++ b/providers/microsoft/azure/tests/unit/microsoft/azure/triggers/test_msgraph.py
@@ -25,6 +25,8 @@ from unittest.mock import patch
 from uuid import uuid4
 
 import pendulum
+import pytest
+from kiota_http.httpx_request_adapter import HttpxRequestAdapter
 from msgraph_core import APIVersion
 
 from airflow.exceptions import AirflowException
@@ -152,6 +154,19 @@ class TestMSGraphTrigger(Base):
 
         for template_field in MSGraphTrigger.template_fields:
             getattr(trigger, template_field)
+
+    def test_get_conn(self):
+        with self.patch_hook():
+            hook = KiotaRequestAdapterHook(conn_id="msgraph_api")
+
+            with pytest.warns(
+                DeprecationWarning,
+                match="get_conn is deprecated, please use the async get_async_conn method!"
+            ):
+                actual = hook.get_conn()
+
+            assert isinstance(actual, HttpxRequestAdapter)
+            assert actual.base_url == "https://graph.microsoft.com/v1.0/"
 
 
 class TestResponseSerializer:


### PR DESCRIPTION
Original Description:
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: [#54350](https://github.com/apache/airflow/issues/54350)
related: [#54350](https://github.com/apache/airflow/issues/54350)

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->

This PR fixes the "You cannot use AsyncToSync in the same thread as an async event loop - just await the async function directly." RuntimeError.  The error originates from the[ Connection.extra_dejson](https://github.com/apache/airflow/blob/main/task-sdk/src/airflow/sdk/definitions/connection.py#L217) property which now masks the secret.

So to temporarely avoid the issue, I just use:

`json.loads(connection.extra)`

instead of:

`connection.extra_dejson`

Beside that, this PR will also check if the BaseHook has the new async aget_connection method, if it does it will use it as is, if it doesn't (which will be the case when azure provider is used with older airflow versions), then it will use the sync_to_async fallbaclk mechanism.

<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [airflow-core/newsfragments](https://github.com/apache/airflow/tree/main/airflow-core/newsfragments).


Original Author: dabla