### PR TITLE
[Forked] Add Clear All Mapped Tasks button for mapped task instances

### DIFF
--- a/airflow-core/src/airflow/ui/public/i18n/locales/en/dags.json
+++ b/airflow-core/src/airflow/ui/public/i18n/locales/en/dags.json
@@ -34,6 +34,11 @@
       "error": "Failed to clear {{type}}",
       "title": "Clear {{type}}"
     },
+    "clearAllMapped": {
+      "button": "Clear All Mapped Tasks",
+      "buttonTooltip": "Clear all mapped task instances",
+      "title": "Clear All Mapped Task Instances"
+    },
     "confirmationDialog": {
       "description": "Task is currently in a {{state}} state started by user {{user}} at {{time}}. \nThe user is unable to clear this task until it is done running or a user unchecks the \"Prevent rerun if task is running\" option in the clear task dialog.",
       "title": "Cannot Clear Task Instance"

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearAllMappedTaskInstancesButton.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearAllMappedTaskInstancesButton.tsx
@@ -1,0 +1,64 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Box, useDisclosure } from "@chakra-ui/react";
+import { useTranslation } from "react-i18next";
+import { CgRedo } from "react-icons/cg";
+
+import { Tooltip } from "src/components/ui";
+import ActionButton from "src/components/ui/ActionButton";
+
+import ClearAllMappedTaskInstancesDialog from "./ClearAllMappedTaskInstancesDialog";
+
+type Props = {
+  readonly dagId: string;
+  readonly dagRunId: string;
+  readonly taskId: string;
+  readonly withText?: boolean;
+};
+
+const ClearAllMappedTaskInstancesButton = ({ dagId, dagRunId, taskId, withText = true }: Props) => {
+  const { onClose, onOpen, open } = useDisclosure();
+  const { t: translate } = useTranslation();
+
+  return (
+    <Tooltip closeDelay={100} content={translate("dags:runAndTaskActions.clearAllMapped.buttonTooltip")} openDelay={100}>
+      <Box>
+        <ActionButton
+          actionName={translate("dags:runAndTaskActions.clearAllMapped.button")}
+          icon={<CgRedo />}
+          onClick={onOpen}
+          text={translate("dags:runAndTaskActions.clearAllMapped.button")}
+          withText={withText}
+        />
+
+        {open ? (
+          <ClearAllMappedTaskInstancesDialog
+            dagId={dagId}
+            dagRunId={dagRunId}
+            onClose={onClose}
+            open={open}
+            taskId={taskId}
+          />
+        ) : undefined}
+      </Box>
+    </Tooltip>
+  );
+};
+
+export default ClearAllMappedTaskInstancesButton;

--- a/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearAllMappedTaskInstancesDialog.tsx
+++ b/airflow-core/src/airflow/ui/src/components/Clear/TaskInstance/ClearAllMappedTaskInstancesDialog.tsx
@@ -1,0 +1,199 @@
+/*!
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import { Button, Flex, Heading, useDisclosure, VStack } from "@chakra-ui/react";
+import { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { CgRedo } from "react-icons/cg";
+
+import type { TaskInstanceResponse } from "openapi/requests/types.gen";
+import { ActionAccordion } from "src/components/ActionAccordion";
+import { Checkbox, Dialog } from "src/components/ui";
+import SegmentedControl from "src/components/ui/SegmentedControl";
+import { useClearTaskInstances } from "src/queries/useClearTaskInstances";
+import { useClearTaskInstancesDryRun } from "src/queries/useClearTaskInstancesDryRun";
+import { isStatePending, useAutoRefresh } from "src/utils";
+
+import ClearTaskInstanceConfirmationDialog from "./ClearTaskInstanceConfirmationDialog";
+
+type Props = {
+  readonly dagId: string;
+  readonly dagRunId: string;
+  readonly onClose: () => void;
+  readonly open: boolean;
+  readonly taskId: string;
+};
+
+const ClearAllMappedTaskInstancesDialog = ({
+  dagId,
+  dagRunId,
+  onClose: onCloseDialog,
+  open: openDialog,
+  taskId,
+}: Props) => {
+  const { t: translate } = useTranslation();
+  const { onClose, onOpen, open } = useDisclosure();
+
+  const { isPending, mutate } = useClearTaskInstances({
+    dagId,
+    dagRunId,
+    onSuccessConfirm: onCloseDialog,
+  });
+
+  const [selectedOptions, setSelectedOptions] = useState<Array<string>>(["downstream"]);
+
+  const onlyFailed = selectedOptions.includes("onlyFailed");
+  const past = selectedOptions.includes("past");
+  const future = selectedOptions.includes("future");
+  const upstream = selectedOptions.includes("upstream");
+  const downstream = selectedOptions.includes("downstream");
+  const [preventRunningTask, setPreventRunningTask] = useState(true);
+
+  const refetchInterval = useAutoRefresh({ dagId });
+
+  // Pass just taskId (without mapIndex) to clear ALL mapped instances
+  const { data } = useClearTaskInstancesDryRun({
+    dagId,
+    options: {
+      enabled: openDialog,
+      refetchInterval: (query) =>
+        query.state.data?.task_instances.some((ti: TaskInstanceResponse) => isStatePending(ti.state))
+          ? refetchInterval
+          : false,
+      refetchOnMount: "always",
+    },
+    requestBody: {
+      dag_run_id: dagRunId,
+      include_downstream: downstream,
+      include_future: future,
+      include_past: past,
+      include_upstream: upstream,
+      only_failed: onlyFailed,
+      task_ids: [taskId], // Just taskId to clear all map indices
+    },
+  });
+
+  const affectedTasks = data ?? {
+    task_instances: [],
+    total_entries: 0,
+  };
+
+  return (
+    <>
+      <Dialog.Root lazyMount onOpenChange={onCloseDialog} open={openDialog ? !open : false} size="xl">
+        <Dialog.Content backdrop>
+          <Dialog.Header>
+            <VStack align="start" gap={4}>
+              <Heading size="xl">
+                <strong>{translate("dags:runAndTaskActions.clearAllMapped.title")}:</strong> {taskId}
+              </Heading>
+            </VStack>
+          </Dialog.Header>
+
+          <Dialog.CloseTrigger />
+
+          <Dialog.Body width="full">
+            <Flex justifyContent="center">
+              <SegmentedControl
+                defaultValues={["downstream"]}
+                multiple
+                onChange={setSelectedOptions}
+                options={[
+                  {
+                    label: translate("dags:runAndTaskActions.options.past"),
+                    value: "past",
+                  },
+                  {
+                    label: translate("dags:runAndTaskActions.options.future"),
+                    value: "future",
+                  },
+                  {
+                    label: translate("dags:runAndTaskActions.options.upstream"),
+                    value: "upstream",
+                  },
+                  {
+                    label: translate("dags:runAndTaskActions.options.downstream"),
+                    value: "downstream",
+                  },
+                  {
+                    label: translate("dags:runAndTaskActions.options.onlyFailed"),
+                    value: "onlyFailed",
+                  },
+                ]}
+              />
+            </Flex>
+            <ActionAccordion affectedTasks={affectedTasks} />
+            <Flex justifyContent="space-between" mt={3}>
+              <Checkbox
+                checked={preventRunningTask}
+                onCheckedChange={(event) => setPreventRunningTask(Boolean(event.checked))}
+              >
+                {translate("dags:runAndTaskActions.options.preventRunningTasks")}
+              </Checkbox>
+              <Button
+                colorPalette="brand"
+                disabled={affectedTasks.total_entries === 0}
+                loading={isPending}
+                onClick={onOpen}
+              >
+                <CgRedo /> {translate("modal.confirm")}
+              </Button>
+            </Flex>
+          </Dialog.Body>
+        </Dialog.Content>
+      </Dialog.Root>
+      {open ? (
+        <ClearTaskInstanceConfirmationDialog
+          dagDetails={{
+            dagId,
+            dagRunId,
+            downstream,
+            future,
+            mapIndex: -1, // Not applicable for all mapped
+            onlyFailed,
+            past,
+            taskId,
+            upstream,
+          }}
+          onClose={onClose}
+          onConfirm={() => {
+            mutate({
+              dagId,
+              requestBody: {
+                dag_run_id: dagRunId,
+                dry_run: false,
+                include_downstream: downstream,
+                include_future: future,
+                include_past: past,
+                include_upstream: upstream,
+                only_failed: onlyFailed,
+                task_ids: [taskId], // Just taskId to clear all map indices
+                ...(preventRunningTask ? { prevent_running_task: true } : {}),
+              },
+            });
+            onCloseDialog();
+          }}
+          open={open}
+          preventRunningTask={preventRunningTask}
+        />
+      ) : null}
+    </>
+  );
+};
+
+export default ClearAllMappedTaskInstancesDialog;

--- a/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Header.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/Header.tsx
@@ -22,11 +22,18 @@ import { useTranslation } from "react-i18next";
 import { MdOutlineTask } from "react-icons/md";
 
 import type { LightGridTaskInstanceSummary } from "openapi/requests/types.gen";
+import ClearAllMappedTaskInstancesButton from "src/components/Clear/TaskInstance/ClearAllMappedTaskInstancesButton";
 import { HeaderCard } from "src/components/HeaderCard";
 import Time from "src/components/Time";
 import { getDuration } from "src/utils";
 
-export const Header = ({ taskInstance }: { readonly taskInstance: LightGridTaskInstanceSummary }) => {
+type Props = {
+  readonly dagId: string;
+  readonly dagRunId: string;
+  readonly taskInstance: LightGridTaskInstanceSummary;
+};
+
+export const Header = ({ dagId, dagRunId, taskInstance }: Props) => {
   const { t: translate } = useTranslation();
   const entries: Array<{ label: string; value: number | ReactNode | string }> = [];
   let taskCount: number = 0;
@@ -55,6 +62,13 @@ export const Header = ({ taskInstance }: { readonly taskInstance: LightGridTaskI
   return (
     <Box>
       <HeaderCard
+        actions={
+          <ClearAllMappedTaskInstancesButton
+            dagId={dagId}
+            dagRunId={dagRunId}
+            taskId={taskInstance.task_id}
+          />
+        }
         icon={<MdOutlineTask />}
         state={taskInstance.state}
         stats={stats}

--- a/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/MappedTaskInstance.tsx
+++ b/airflow-core/src/airflow/ui/src/pages/MappedTaskInstance/MappedTaskInstance.tsx
@@ -45,7 +45,9 @@ export const MappedTaskInstance = () => {
   return (
     <ReactFlowProvider>
       <DetailsLayout tabs={tabs}>
-        {taskInstance === undefined ? undefined : <Header taskInstance={taskInstance} />}
+        {taskInstance === undefined ? undefined : (
+          <Header dagId={dagId} dagRunId={runId} taskInstance={taskInstance} />
+        )}
       </DetailsLayout>
     </ReactFlowProvider>
   );


### PR DESCRIPTION
Original Description:
## Summary

This PR adds a "Clear All Mapped Tasks" button to the mapped task instance header, allowing users to clear all mapped task instances at once.

Closes #60460

## Problem

Currently, there is no way to clear all mapped task instances at once for a specific task. Users have to clear each individual mapped task instance separately, which is tedious when dealing with many mapped instances.

## Solution

Added a "Clear All Mapped Tasks" button to the mapped task instance header that clears all map indices for a given task. The backend already supports this functionality - when only the `task_id` is provided (without `map_index`), all map indices are targeted for clearing.

## Changes

- **ClearAllMappedTaskInstancesButton.tsx**: New button component that triggers the dialog
- **ClearAllMappedTaskInstancesDialog.tsx**: New dialog component similar to ClearTaskInstanceDialog, but uses `task_ids: [taskId]` instead of `[[taskId, mapIndex]]` to clear all mapped instances
- **Header.tsx**: Updated to accept `dagId` and `dagRunId` props and render the new button
- **MappedTaskInstance.tsx**: Updated to pass `dagId` and `dagRunId` to the Header component
- **dags.json**: Added translation keys for the new feature

## Screenshot Location

The button appears in the header of the mapped task instance page (e.g., `/dags/{dag_id}/runs/{run_id}/tasks/{task_id}/mapped`), next to the task name and statistics.

## Testing

- TypeScript compilation passes
- The feature uses existing backend functionality that already supports clearing all mapped instances
- The dialog follows the same patterns as the existing ClearTaskInstanceDialog


Original Author: VedantMadane