### PR TITLE
[Forked] S3 Copy Operator: Support Custom KMS Keys

### DIFF
--- a/providers/amazon/src/airflow/providers/amazon/aws/operators/s3.py
+++ b/providers/amazon/src/airflow/providers/amazon/aws/operators/s3.py
@@ -296,6 +296,10 @@ class S3CopyObjectOperator(AwsBaseOperator[S3Hook]):
         uploaded to the S3 bucket.
     :param meta_data_directive: Whether to `COPY` the metadata from the source object or `REPLACE` it with
         metadata that's provided in the request.
+    :param kms_key_id: The ARN, id or alias of the AWS KMS key to use for encrypting the destination object.
+        Required if using KMS-based server-side encryption with a non-default key.
+    :param kms_encryption_type: Type of KMS encryption to use for the object.
+        Can be either "aws:kms" (standard KMS) or "aws:kms:dsse" (double-shielded KMS).
     """
 
     template_fields: Sequence[str] = aws_template_fields(
@@ -316,6 +320,8 @@ class S3CopyObjectOperator(AwsBaseOperator[S3Hook]):
         source_version_id: str | None = None,
         acl_policy: str | None = None,
         meta_data_directive: str | None = None,
+        kms_key_id: str | None = None,
+        kms_encryption_type: str | None = None,
         **kwargs,
     ):
         super().__init__(**kwargs)
@@ -327,8 +333,16 @@ class S3CopyObjectOperator(AwsBaseOperator[S3Hook]):
         self.source_version_id = source_version_id
         self.acl_policy = acl_policy
         self.meta_data_directive = meta_data_directive
+        self.kms_key_id = kms_key_id
+        self.kms_encryption_type = kms_encryption_type
 
     def execute(self, context: Context):
+        copy_args = {}
+        if self.kms_key_id:
+            copy_args["SSEKMSKeyId"] = self.kms_key_id
+        if self.kms_encryption_type:
+            copy_args["ServerSideEncryption"] = self.kms_encryption_type
+
         self.hook.copy_object(
             self.source_bucket_key,
             self.dest_bucket_key,
@@ -337,6 +351,7 @@ class S3CopyObjectOperator(AwsBaseOperator[S3Hook]):
             self.source_version_id,
             self.acl_policy,
             self.meta_data_directive,
+            **copy_args,
         )
 
     def get_openlineage_facets_on_start(self):

--- a/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/hooks/test_s3.py
@@ -1312,6 +1312,29 @@ class TestAwsS3Hook:
             )
 
     @mock_aws
+    def test_copy_object_with_kms_encryption(self, s3_bucket):
+        mock_hook = S3Hook()
+
+        with mock.patch.object(S3Hook, "get_conn") as patched_get_conn:
+            mock_hook.copy_object(
+                "my_key",
+                "my_key_encrypted",
+                s3_bucket,
+                s3_bucket,
+                SSEKMSKeyId="arn:aws:kms:us-east-1:123456789012:key/abcd1234",
+                ServerSideEncryption="aws:kms",
+            )
+
+            patched_get_conn.return_value.copy_object.assert_called_once_with(
+                Bucket=s3_bucket,
+                Key="my_key_encrypted",
+                CopySource={"Bucket": s3_bucket, "Key": "my_key", "VersionId": None},
+                ACL="private",
+                SSEKMSKeyId="arn:aws:kms:us-east-1:123456789012:key/abcd1234",
+                ServerSideEncryption="aws:kms",
+            )
+
+    @mock_aws
     def test_delete_bucket_if_bucket_exist(self, s3_bucket):
         # assert if the bucket is created
         mock_hook = S3Hook()

--- a/providers/amazon/tests/unit/amazon/aws/operators/test_s3.py
+++ b/providers/amazon/tests/unit/amazon/aws/operators/test_s3.py
@@ -591,6 +591,91 @@ class TestS3CopyObjectOperator:
         )
         validate_template_fields(operator)
 
+    @mock_aws
+    def test_s3_copy_object_with_kms(self, monkeypatch):
+        conn = boto3.client("s3")
+        conn.create_bucket(Bucket=self.source_bucket)
+        conn.create_bucket(Bucket=self.dest_bucket)
+        conn.upload_fileobj(Bucket=self.source_bucket, Key=self.source_key, Fileobj=BytesIO(b"input"))
+
+        kms_key_id = "arn:aws:kms:us-east-1:123456789012:key/abcd1234"
+        captured_kwargs = {}
+
+        def fake_copy_object(
+            self_hook,
+            source_bucket_key,
+            dest_bucket_key,
+            source_bucket_name=None,
+            dest_bucket_name=None,
+            source_version_id=None,
+            acl_policy=None,
+            meta_data_directive=None,
+            **kwargs,
+        ):
+            nonlocal captured_kwargs
+            captured_kwargs = kwargs
+            copy_source = {"Bucket": source_bucket_name, "Key": source_bucket_key}
+            self_hook.get_conn().copy_object(
+                Bucket=dest_bucket_name, Key=dest_bucket_key, CopySource=copy_source, **kwargs
+            )
+
+        monkeypatch.setattr(S3Hook, "copy_object", fake_copy_object)
+        op = S3CopyObjectOperator(
+            task_id="test_task_s3_copy_object",
+            source_bucket_key=self.source_key,
+            source_bucket_name=self.source_bucket,
+            dest_bucket_key=self.dest_key,
+            dest_bucket_name=self.dest_bucket,
+            kms_key_id=kms_key_id,
+            kms_encryption_type="aws:kms",
+        )
+        op.execute(None)
+        assert captured_kwargs["SSEKMSKeyId"] == kms_key_id
+        assert captured_kwargs["ServerSideEncryption"] == "aws:kms"
+        objects_in_dest_bucket = conn.list_objects(Bucket=self.dest_bucket, Prefix=self.dest_key)
+        assert len(objects_in_dest_bucket["Contents"]) == 1
+        assert objects_in_dest_bucket["Contents"][0]["Key"] == self.dest_key
+
+    @mock_aws
+    def test_s3_copy_object_fails_without_kms_key(self, monkeypatch):
+        conn = boto3.client("s3")
+        conn.create_bucket(Bucket=self.source_bucket)
+        conn.create_bucket(Bucket=self.dest_bucket)
+        conn.upload_fileobj(Bucket=self.source_bucket, Key=self.source_key, Fileobj=BytesIO(b"input"))
+
+        def fake_copy_object(
+            self_hook,
+            source_bucket_key,
+            dest_bucket_key,
+            source_bucket_name=None,
+            dest_bucket_name=None,
+            source_version_id=None,
+            acl_policy=None,
+            meta_data_directive=None,
+            **kwargs,
+        ):
+            if "SSEKMSKeyId" not in kwargs:
+                raise boto3.client("s3").exceptions.ClientError(
+                    {"Error": {"Code": "AccessDenied", "Message": "Missing KMS key"}}, "CopyObject"
+                )
+            copy_source = {"Bucket": source_bucket_name, "Key": source_bucket_key}
+            self_hook.get_conn().copy_object(
+                Bucket=dest_bucket_name, Key=dest_bucket_key, CopySource=copy_source, **kwargs
+            )
+
+        monkeypatch.setattr(S3Hook, "copy_object", fake_copy_object)
+        op = S3CopyObjectOperator(
+            task_id="test_task_s3_copy_object",
+            source_bucket_key=self.source_key,
+            source_bucket_name=self.source_bucket,
+            dest_bucket_key=self.dest_key,
+            dest_bucket_name=self.dest_bucket,
+            kms_encryption_type="aws:kms",
+        )
+        with pytest.raises(boto3.client("s3").exceptions.ClientError) as exc_info:
+            op.execute(None)
+        assert "Missing KMS key" in str(exc_info.value)
+
 
 @mock_aws
 class TestS3DeleteObjectsOperator:


### PR DESCRIPTION
Original Description:

closes: #55708

This PR introduces 2 new parameters to the S3CopyObjectOperator. With these one can specify a non-default KMS key when copying objects between buckets.


- `kms_key_id`: The ARN, ID or alias of a KMS key
- `kms_encryption_type`: Whether it is standard KMS or double-shielded KMS

The parameters are passed to the Hooks `copy_object()` method using kwargs, which passes them to the boto3 method.
I did this to not introduce new parameters to the method and keep changes minimal, however I also see a point that this is not as clean as passing them to the method via parameters and if deemed preferential will change that.

---

##### Was generative AI tooling used to co-author this PR?

<!--
If generative AI tooling has been used in the process of authoring this PR, please
change below checkbox to `[X]` followed by the name of the tool, uncomment the "Generated-by".
-->

- [] Yes  

<!--
Generated-by: [gpt o5] following [the guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#gen-ai-assisted-contributions)
-->

---


Original Author: dominikhei